### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,15 @@
 > 🍭A free, plug-and-play knowledge base. Built-in with 10,000+ high-quality insight reports, packaged as MCP Server, and secure local data storage.
 
 ⚠️⚠️ All collected reports in this project come from free resources on official research report websites. ⚠️⚠️
+
+<a href="https://glama.ai/mcp/servers/@v587d/InsightsLibrary">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@v587d/InsightsLibrary/badge" alt="Insights Knowledge Base Server MCP server" />
+</a>
+
 ## Features
 1. 🍾 No configuration needed, truly plug-and-play. For private document parsing, configure VLM models and parameters in `.env` (e.g., `VLM_MODEL_NAME=qwen2.5-vl-72b-instruct`).
 2. 🦉 Permanently free - no need to waste effort collecting report resources. Welcome to share reliable, copyright-free report sources via `issues`.
 3. 📢 Committed to weekly report updates, but bug fixes depend on my mood (I'm not a programmer 🤭).
-
 
 [![introduction video](https://i9.ytimg.com/vi_webp/Mb8KbPo7EVM/mq2.webp?sqp=CKyUqsIG-oaymwEmCMACELQB8quKqQMa8AEB-AH-CYAC0AWKAgwIABABGGUgZShlMA8=&rs=AOn4CLCU6ruFrPJY5usKxhGMG4EsHbwvDw)][https://youtu.be/Mb8KbPo7EVM]
 


### PR DESCRIPTION
This PR adds a badge for the [Insights Knowledge Base MCP Server](https://glama.ai/mcp/servers/@v587d/InsightsLibrary) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@v587d/InsightsLibrary">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@v587d/InsightsLibrary/badge" alt="Insights Knowledge Base Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.